### PR TITLE
NN-82-FixesHiddenArmBug

### DIFF
--- a/Assets/Scripts/Nimbus/NimbusLatch.cs
+++ b/Assets/Scripts/Nimbus/NimbusLatch.cs
@@ -24,7 +24,7 @@ public class NimbusLatch : MonoBehaviour
             transform.position = Vector2.MoveTowards(transform.position, latchTarget, latchSpeed * Time.deltaTime);
 
             // Check if Nimbus has reached the latch point
-            if (Vector2.Distance(transform.position, latchTarget) < 0.1f)
+            if (Vector2.Distance(transform.position, latchTarget) < 0.01f)
             {
                 CompleteLatch();
             }


### PR DESCRIPTION
Cause of the bug: NimbusLatch ended when within 0.1 of left/right point. This creates random ending spot. I lowered it to 0.01 so it ends more stably to the position set. If similar bug still appears in the future, then it is likely *point left* of cloud needs to move a bit. 

For now i'm not seeing the bug appearing anymore.